### PR TITLE
Tokio

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,8 @@ name = "beanstalkc"
 path = "src/lib.rs"
 
 [dependencies]
-bufstream = "0.1.4"
+bufstream = { version = "0.1.4", features = ["tokio"] }
+tokio = { version = "1", features = ["full"] }
 serde = "^1.0"
 serde_yaml = "^0.8"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ name = "beanstalkc"
 path = "src/lib.rs"
 
 [dependencies]
-bufstream = { version = "0.1.4", features = ["tokio"] }
 tokio = { version = "1", features = ["full"] }
 serde = "^1.0"
 serde_yaml = "^0.8"

--- a/Makefile
+++ b/Makefile
@@ -9,13 +9,13 @@ release:
 	cargo build --release
 
 format:
-	cargo fmt
+	cargo fmt --all
 
 lint:
-	cargo clippy
+	cargo clippy --fix --allow-dirty --allow-staged
 
 test:
-	cargo test -- --test-threads=1
+	cargo test --all
 
 clean:
 	cargo clean

--- a/examples/main.rs
+++ b/examples/main.rs
@@ -1,82 +1,93 @@
 extern crate flate2;
 
 use std::error::Error;
-use std::time;
 use std::io::prelude::*;
+use std::time;
 
 use beanstalkc::Beanstalkc;
-use flate2::Compression;
-use flate2::write::GzEncoder;
 use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
 
-fn main() -> Result<(), Box<dyn Error>> {
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn Error>> {
     let mut conn = Beanstalkc::new()
         .host("localhost")
         .port(11300)
         .connection_timeout(Some(time::Duration::from_secs(1)))
         .connect()
+        .await
         .expect("connection failed");
 
-    dbg!(conn.put_default(b"hello"))?;
-    dbg!(conn.put(
-        b"Hello, rust world.",
-        0,
-        time::Duration::from_secs(100),
-        time::Duration::from_secs(1800)
-    ))?;
-    dbg!(conn.reserve())?;
-    dbg!(conn.kick(100))?;
-    dbg!(conn.kick_job(10))?;
-    dbg!(conn.peek(10))?;
-    dbg!(conn.peek_ready())?;
-    dbg!(conn.peek_buried())?;
-    dbg!(conn.peek_delayed())?;
-    dbg!(conn.tubes())?;
-    dbg!(conn.using())?;
-    dbg!(conn.use_tube("jobs"))?;
-    dbg!(conn.watch("jobs"))?;
-    dbg!(conn.watching())?;
-    dbg!(conn.ignore("jobs"))?;
-    dbg!(conn.ignore("default"))?;
-    dbg!(conn.stats_tube("default"))?;
-    dbg!(conn.pause_tube("jobs", time::Duration::from_secs(10)))?;
-    dbg!(conn.pause_tube("not-found", time::Duration::from_secs(10)))?;
+    dbg!(conn.put_default(b"hello").await?);
+    dbg!(
+        conn.put(
+            b"Hello, rust world.",
+            0,
+            time::Duration::from_secs(100),
+            time::Duration::from_secs(1800)
+        )
+        .await?
+    );
+    dbg!(conn.reserve().await?);
+    dbg!(conn.kick(100).await?);
+    dbg!(conn.kick_job(10).await?);
+    dbg!(conn.peek(10).await?);
+    dbg!(conn.peek_ready().await?);
+    dbg!(conn.peek_buried().await?);
+    dbg!(conn.peek_delayed().await?);
+    dbg!(conn.tubes().await?);
+    dbg!(conn.using().await?);
+    dbg!(conn.use_tube("jobs").await?);
+    dbg!(conn.watch("jobs").await?);
+    dbg!(conn.watching().await?);
+    dbg!(conn.ignore("jobs").await?);
+    dbg!(conn.ignore("default").await?);
+    dbg!(conn.stats_tube("default").await?);
+    dbg!(
+        conn.pause_tube("jobs", time::Duration::from_secs(10))
+            .await?
+    );
+    dbg!(
+        conn.pause_tube("not-found", time::Duration::from_secs(10))
+            .await?
+    );
 
-    let mut job = conn.reserve()?;
+    let mut job = conn.reserve().await?;
     dbg!(job.id());
     dbg!(std::str::from_utf8(job.body()))?;
     dbg!(job.reserved());
-    dbg!(job.bury_default())?;
-    dbg!(job.kick())?;
-    dbg!(job.touch())?;
-    dbg!(job.stats())?;
-    dbg!(job.touch())?;
-    dbg!(job.release_default())?;
-    dbg!(job.delete())?;
+    dbg!(job.bury_default().await?);
+    dbg!(job.kick().await?);
+    dbg!(job.touch().await?);
+    dbg!(job.stats().await?);
+    dbg!(job.touch().await?);
+    dbg!(job.release_default().await?);
+    dbg!(job.delete().await?);
 
-    let mut job = conn.reserve()?;
-    dbg!(job.delete())?;
+    let mut job = conn.reserve().await?;
+    dbg!(job.delete().await?);
 
     // should also work with potentially non-UTF-8 payloads
     // puts a gzip encoded message
     let mut e = GzEncoder::new(Vec::new(), Compression::default());
     e.write_all(b"Hello beanstalkc compressed")?;
     let buf = e.finish()?;
-    dbg!(conn.put_default(&buf))?;
+    dbg!(conn.put_default(&buf).await?);
 
     // tries to read the gzipped encoded message back to a string
-    let mut job = conn.reserve()?;
+    let mut job = conn.reserve().await?;
     let mut buf = &job.body().to_owned()[..];
     let mut gz = GzDecoder::new(&mut buf);
     let mut s = String::new();
     gz.read_to_string(&mut s)?;
     dbg!(s);
-    job.delete()?;
+    job.delete().await?;
 
-    let mut conn = conn.reconnect()?;
-    dbg!(conn.stats())?;
+    let mut conn = conn.reconnect().await?;
+    dbg!(conn.stats().await?);
 
-    let stats = conn.stats()?;
+    let stats = conn.stats().await?;
     dbg!(stats);
 
     Ok(())

--- a/src/command.rs
+++ b/src/command.rs
@@ -1,3 +1,4 @@
+use std::fmt;
 use std::str::FromStr;
 use std::string::ToString;
 use std::time::Duration;
@@ -32,8 +33,8 @@ pub enum CommandKind {
     PauseTube,
 }
 
-impl ToString for CommandKind {
-    fn to_string(&self) -> String {
+impl fmt::Display for CommandKind {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let cmd = match *self {
             CommandKind::Put => "put",
             CommandKind::PeekJob => "peek",
@@ -60,7 +61,7 @@ impl ToString for CommandKind {
             CommandKind::Quit => "quit",
             CommandKind::PauseTube => "pause-tube",
         };
-        cmd.to_string()
+        write!(f, "{}", cmd)
     }
 }
 
@@ -198,7 +199,7 @@ pub fn reserve<'a>(timeout: Option<Duration>) -> Command<'a> {
         },
         timeout
             .map(|t| vec![t.as_secs().to_string()])
-            .unwrap_or_else(|| vec![]),
+            .unwrap_or_default(),
         None,
         vec![Status::Reserved],
         vec![Status::TimedOut, Status::DeadlineSoon],

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use std::io;
 use std::net::AddrParseError;
 use std::num::ParseIntError;
-use std::string::FromUtf8Error;
 use std::str::Utf8Error;
+use std::string::FromUtf8Error;
 
 #[derive(Debug, Clone)]
 pub enum BeanstalkcError {

--- a/src/job.rs
+++ b/src/job.rs
@@ -57,15 +57,18 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.delete().unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.delete().await.unwrap();
+    /// }
     /// ```
-    pub fn delete(&mut self) -> BeanstalkcResult<()> {
-        self.conn.delete(self.id)?;
+    pub async fn delete(&mut self) -> BeanstalkcResult<()> {
+        self.conn.delete(self.id).await?;
         self.reserved = false;
         Ok(())
     }
@@ -75,16 +78,19 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.release_default().unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.release_default().await.unwrap();
+    /// }
     /// ```
-    pub fn release_default(&mut self) -> BeanstalkcResult<()> {
-        let priority = self.priority();
-        self.release(priority, DEFAULT_JOB_DELAY)
+    pub async fn release_default(&mut self) -> BeanstalkcResult<()> {
+        let priority = self.priority().await;
+        self.release(priority, DEFAULT_JOB_DELAY).await
     }
 
     /// Release this job back to the ready queue with custom priority and delay.
@@ -92,20 +98,23 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.release(0, Duration::from_secs(0)).unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.release(0, Duration::from_secs(0)).await.unwrap();
+    /// }
     /// ```
-    pub fn release(&mut self, priority: u32, delay: Duration) -> BeanstalkcResult<()> {
+    pub async fn release(&mut self, priority: u32, delay: Duration) -> BeanstalkcResult<()> {
         if !self.reserved {
             return Ok(());
         }
 
-        self.conn.release(self.id, priority, delay)?;
+        self.conn.release(self.id, priority, delay).await?;
         self.reserved = false;
         Ok(())
     }
@@ -115,17 +124,20 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.bury_default().unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.bury_default().await.unwrap();
+    /// }
     /// ```
-    pub fn bury_default(&mut self) -> BeanstalkcResult<()> {
-        let priority = self.priority();
-        self.bury(priority)
+    pub async fn bury_default(&mut self) -> BeanstalkcResult<()> {
+        let priority = self.priority().await;
+        self.bury(priority).await
     }
 
     /// Bury this job with custom priority.
@@ -133,20 +145,23 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.bury(1024).unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.bury(1024).await.unwrap();
+    /// }
     /// ```
-    pub fn bury(&mut self, priority: u32) -> BeanstalkcResult<()> {
+    pub async fn bury(&mut self, priority: u32) -> BeanstalkcResult<()> {
         if !self.reserved {
             return Ok(());
         }
 
-        self.conn.bury(self.id, priority)?;
+        self.conn.bury(self.id, priority).await?;
         self.reserved = false;
         Ok(())
     }
@@ -156,16 +171,19 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.peek_buried().unwrap();
-    /// job.kick().unwrap();
+    /// let mut job = conn.peek_buried().await.unwrap();
+    /// job.kick().await.unwrap();
+    /// }
     /// ```
-    pub fn kick(&mut self) -> BeanstalkcResult<()> {
-        self.conn.kick_job(self.id)
+    pub async fn kick(&mut self) -> BeanstalkcResult<()> {
+        self.conn.kick_job(self.id).await
     }
 
     /// Touch this reserved job, requesting more time to work on it.
@@ -173,20 +191,23 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.reserve().unwrap();
-    /// job.touch().unwrap();
+    /// let mut job = conn.reserve().await.unwrap();
+    /// job.touch().await.unwrap();
+    /// }
     /// ```
-    pub fn touch(&mut self) -> BeanstalkcResult<()> {
+    pub async fn touch(&mut self) -> BeanstalkcResult<()> {
         if !self.reserved {
             return Ok(());
         }
 
-        self.conn.touch(self.id)
+        self.conn.touch(self.id).await
     }
 
     /// Return a dict of statistical information about this job.
@@ -194,22 +215,25 @@ impl<'a> Job<'a> {
     /// # Example
     ///
     /// ```no_run
+    /// #[tokio::main]
+    /// async fn main() {
     /// use std::time::Duration;
     /// use beanstalkc::Beanstalkc;
     ///
-    /// let mut conn = Beanstalkc::new().connect().unwrap();
+    /// let mut conn = Beanstalkc::new().connect().await.unwrap();
     ///
-    /// let mut job = conn.peek_ready().unwrap();
-    /// let job_stats = job.stats().unwrap();
+    /// let mut job = conn.peek_ready().await.unwrap();
+    /// let job_stats = job.stats().await.unwrap();
     /// dbg!(job_stats);
+    /// }
     /// ```
-    pub fn stats(&mut self) -> BeanstalkcResult<HashMap<String, String>> {
-        self.conn.stats_job(self.id)
+    pub async fn stats(&mut self) -> BeanstalkcResult<HashMap<String, String>> {
+        self.conn.stats_job(self.id).await
     }
 
     /// Return the job priority from this job stats. If not found, return the `DEFAULT_JOB_PRIORITY`.
-    fn priority(&mut self) -> u32 {
-        let stats = self.stats().unwrap_or_default();
+    async fn priority(&mut self) -> u32 {
+        let stats = self.stats().await.unwrap_or_default();
         stats
             .get("pri")
             .map(|x| x.parse().unwrap_or(DEFAULT_JOB_PRIORITY))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,32 +13,40 @@
 //! Producer
 //!
 //! ```no_run
+//! #[tokio::main]
+//! async fn main() {
 //! use std::time::Duration;
 //! use beanstalkc::Beanstalkc;
 //!
 //! let mut conn = Beanstalkc::new()
 //!      .connect()
+//!      .await
 //!      .expect("connect to beanstalkd server failed");
 //!
-//! conn.use_tube("jobs").unwrap();
-//! conn.put_default(b"hello, world").unwrap();
-//! conn.put(b"hello, rust", 1, Duration::from_secs(10), Duration::from_secs(1800)).unwrap();
+//! conn.use_tube("jobs").await.unwrap();
+//! conn.put_default(b"hello, world").await.unwrap();
+//! conn.put(b"hello, rust", 1, Duration::from_secs(10), Duration::from_secs(1800)).await.unwrap();
+//! }
 //! ```
 //!
 //! Worker
 //!
 //! ```no_run
+//! #[tokio::main]
+//! async fn main() {
 //! use beanstalkc::Beanstalkc;
 //!
 //! let mut conn = Beanstalkc::new()
 //!      .connect()
+//!      .await
 //!      .expect("connect to beanstalkd server failed");
 //!
-//! conn.watch("jobs").unwrap();
+//! conn.watch("jobs").await.unwrap();
 //!
-//! let mut job = conn.reserve().unwrap();
+//! let mut job = conn.reserve().await.unwrap();
 //! // execute job here...
-//! job.delete().unwrap();
+//! job.delete().await.unwrap();
+//! }
 //! ```
 pub use crate::beanstalkc::Beanstalkc;
 pub use crate::error::{BeanstalkcError, BeanstalkcResult};

--- a/src/response.rs
+++ b/src/response.rs
@@ -1,6 +1,5 @@
 use crate::command::Status;
 use crate::error::{BeanstalkcError, BeanstalkcResult};
-use serde_yaml;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -36,7 +35,7 @@ impl Response {
             Some(b) => {
                 let b = std::str::from_utf8(b)?;
                 serde_yaml::from_str(b).unwrap_or_default()
-            },
+            }
         };
         Ok(res)
     }


### PR DESCRIPTION
```
make all
cargo fmt --all
cargo clippy --fix --allow-dirty --allow-staged
    Checking beanstalkc v1.0.0 (/Users/cody/repos/CodyPubNub/beanstalkc-rust)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.93s
cargo build
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.12s
cargo test --all
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.05s
     Running unittests src/lib.rs (target/debug/deps/beanstalkc-5b7e839666081b71)

running 25 tests
test command::tests::test_bury ... ok
test command::tests::test_delete ... ok
test command::tests::test_kick_job ... ok
test command::tests::test_kick ... ok
test command::tests::test_ignore ... ok
test command::tests::test_list_tubes ... ok
test command::tests::test_peek_buried ... ok
test command::tests::test_pause_tube ... ok
test command::tests::test_peek_job ... ok
test command::tests::test_peek_ready ... ok
test command::tests::test_put ... ok
test command::tests::test_quit ... ok
test command::tests::test_release ... ok
test command::tests::test_reserve ... ok
test command::tests::test_stats_job ... ok
test command::tests::test_stats_tube ... ok
test command::tests::test_touch ... ok
test command::tests::test_tube_used ... ok
test command::tests::test_tubes_watched ... ok
test command::tests::test_use_tube ... ok
test command::tests::test_watch ... ok
test response::tests::test_get_int_param ... ok
test response::tests::test_get_body_as_map ... ok
test response::tests::test_get_job_id ... ok
test response::tests::test_get_body_as_vec ... ok

test result: ok. 25 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s

   Doc-tests beanstalkc

running 42 tests
test src/beanstalkc.rs - beanstalkc::Beanstalkc::bury (line 673) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::connection_timeout (line 74) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::connect (line 108) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::ignore (line 513) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::connect (line 97) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::kick (line 285) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::kick_job (line 305) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::delete (line 588) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::bury_default (line 655) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::host (line 39) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::release (line 629) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::port (line 56) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::pause_tube (line 568) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::peek (line 323) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::put (line 193) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::peek_delayed (line 362) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::put_default (line 169) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::peek_ready (line 342) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::reconnect (line 151) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::peek_buried (line 382) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::release_default (line 610) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::using (line 431) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::reserve (line 225) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::touch (line 692) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::use_tube (line 452) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::tubes (line 412) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::reserve_with_timeout (line 255) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::stats_job (line 710) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::stats (line 532) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::stats_tube (line 550) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::watch (line 492) - compile ... ok
test src/job.rs - job::Job<'a>::bury (line 147) - compile ... ok
test src/job.rs - job::Job<'a>::release_default (line 80) - compile ... ok
test src/job.rs - job::Job<'a>::bury_default (line 126) - compile ... ok
test src/beanstalkc.rs - beanstalkc::Beanstalkc::watching (line 473) - compile ... ok
test src/job.rs - job::Job<'a>::kick (line 173) - compile ... ok
test src/job.rs - job::Job<'a>::delete (line 59) - compile ... ok
test src/job.rs - job::Job<'a>::release (line 100) - compile ... ok
test src/job.rs - job::Job<'a>::stats (line 217) - compile ... ok
test src/lib.rs - (line 15) - compile ... ok
test src/job.rs - job::Job<'a>::touch (line 193) - compile ... ok
test src/lib.rs - (line 34) - compile ... ok

test result: ok. 42 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.37s
```